### PR TITLE
fix: use full packages.uds.dev for package wait

### DIFF
--- a/common/zarf.yaml
+++ b/common/zarf.yaml
@@ -26,7 +26,7 @@ components:
             maxTotalSeconds: 300
             wait:
               cluster:
-                kind: Packages
+                kind: packages.uds.dev
                 name: #TEMPLATE_APPLICATION_NAME#
                 namespace: #TEMPLATE_APPLICATION_NAME#
                 condition: "'{.status.phase}'=Ready"


### PR DESCRIPTION
## Description
UDS Packages need to use `packages.uds.dev` in their wait actions. Package is a common kubernetes custom resource name in other applications and causes conflicts when just looking for the Package kind.

## Related Issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-#TEMPLATE_APPLICATION_NAME#/blob/main/CONTRIBUTING.md#developer-workflow) followed
