### PR TITLE
docs: extra commas in README-template.md

### DIFF
--- a/README-template.md
+++ b/README-template.md
@@ -4,7 +4,7 @@
 [![Build Status](https://img.shields.io/github/actions/workflow/status/defenseunicorns/uds-package-#TEMPLATE_APPLICATION_NAME#/tag-and-release.yaml)](https://github.com/defenseunicorns/uds-package-#TEMPLATE_APPLICATION_NAME#/actions/workflows/tag-and-release.yaml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/defenseunicorns/uds-package-#TEMPLATE_APPLICATION_NAME#/badge)](https://api.securityscorecards.dev/projects/github.com/defenseunicorns/uds-package-#TEMPLATE_APPLICATION_NAME#)
 
-This package is designed to be deployed on [UDS Core](https://github.com/defenseunicorns/uds-core), , and is based on the upstream [#TEMPLATE_APPLICATION_DISPLAY_NAME#]() chart.
+This package is designed to be deployed on [UDS Core](https://github.com/defenseunicorns/uds-core) and is based on the upstream [#TEMPLATE_APPLICATION_DISPLAY_NAME#]() chart.
 
 ## Pre-requisites
 


### PR DESCRIPTION
## Description
There seems to be some extra commas in `README-template.md`. If these commas are here to add some other types of dependencies, I think that should be clearly denoted instead as the intentions aren't clear (at least to me).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-#TEMPLATE_APPLICATION_NAME#/blob/main/CONTRIBUTING.md#developer-workflow) followed
