### PR TITLE
docs: change upstream chart template in README-template.md

### DIFF
--- a/README-template.md
+++ b/README-template.md
@@ -4,7 +4,7 @@
 [![Build Status](https://img.shields.io/github/actions/workflow/status/defenseunicorns/uds-package-#TEMPLATE_APPLICATION_NAME#/tag-and-release.yaml)](https://github.com/defenseunicorns/uds-package-#TEMPLATE_APPLICATION_NAME#/actions/workflows/tag-and-release.yaml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/defenseunicorns/uds-package-#TEMPLATE_APPLICATION_NAME#/badge)](https://api.securityscorecards.dev/projects/github.com/defenseunicorns/uds-package-#TEMPLATE_APPLICATION_NAME#)
 
-This package is designed to be deployed on [UDS Core](https://github.com/defenseunicorns/uds-core), , and is based on the upstream [#TEMPLATE_APPLICATION_DISPLAY_NAME#]() chart.
+This package is designed to be deployed on [UDS Core](https://github.com/defenseunicorns/uds-core), , and is based on the upstream [#TEMPLATE_APPLICATION_DISPLAY_NAME# chart](#TEMPLATE_CHART_REPO##TEMPLATE_APPLICATION_NAME#).
 
 ## Pre-requisites
 


### PR DESCRIPTION
## Description
This PR proposes to add a link to the upstream Helm chart in the `README-template.md` file. Currently, the url field is blank, but we are already making a templated assumption of the chart location in other files, so this change implements that assumption to the `README-template.md` file as well. This would follow [the template already used in `docs/configuration.md`](https://github.com/defenseunicorns/uds-package-template/blob/f2b82168e22c83965524f0bfb718f5c4fb1fe331/docs/configuration.md?plain=1#L3).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-#TEMPLATE_APPLICATION_NAME#/blob/main/CONTRIBUTING.md#developer-workflow) followed
