### PR TITLE
fix: create dependencies not only main package

### DIFF
--- a/tasks.yaml
+++ b/tasks.yaml
@@ -26,6 +26,7 @@ tasks:
   - name: create-dev-package
     description: Create the package
     actions:
+      - task: dependencies:create
       - task: create:package
         with:
           options: "--skip-sbom"


### PR DESCRIPTION
Adds step to create dependencies so you don't get a missing package error down the road.

Change tested locally on my chaos-mesh repo.

## Description

...

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-#TEMPLATE_APPLICATION_NAME#/blob/main/CONTRIBUTING.md#developer-workflow) followed
