### PR TITLE
chore!: rename `custom` value for better clarity

### DIFF
--- a/chart/templates/uds-package.yaml
+++ b/chart/templates/uds-package.yaml
@@ -53,7 +53,7 @@ spec:
         remoteGenerated: IntraNamespace
 
       # Custom rules for unanticipated scenarios
-      {{- range .Values.custom }}
+      {{- range .Values.additionalNetworkAllow }}
       - direction: {{ .direction }}
         selector:
           {{ .selector | toYaml | nindent 10 }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -10,7 +10,8 @@ sso:
   adminGroups: ["/#TEMPLATE_APPLICATION_DISPLAY_NAME# Admin", "/UDS Core/Admin"]
   saml:
     providerName: "#TEMPLATE_APPLICATION_DISPLAY_NAME#"
-custom: []
+# Support for custom `network.allow` entries on the Package CR
+additionalNetworkAllow: []
 #    # Notice no `remoteGenerated` field here on custom internal rule
 #   - direction: Ingress
 #     selector:


### PR DESCRIPTION
## Description

The name `custom` for this value is extremely ambiguous and not helpful in describing the intent. While the commented out example value is somewhat helpful I think we should name this value more clearly. I'm open to other suggestions on the right name here but am proposing `additionalNetworkAllow` which aligns with the `Package` CR spec field more directly.

I know this pattern has been copied around to a number of packages so this change may need to be proposed across other packages as well.

## Related Issue

N/A, can open one if more discussion is needed.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-#TEMPLATE_APPLICATION_NAME#/blob/main/CONTRIBUTING.md#developer-workflow) followed
