### PR TITLE
feat: add cve template to manually report CVEs on uds packages

### DIFF
--- a/.github/ISSUE_TEMPLATE/cve_report.md
+++ b/.github/ISSUE_TEMPLATE/cve_report.md
@@ -8,20 +8,10 @@ assignees: ''
 
 ### CVE Details
 - **CVE ID**: 
-- **Package/Container Name**: 
-- **Affected Versions**: 
-- **CVE Description**: 
-
-### Environment
-- **Device and OS**: 
-- **App/Package Versions**: 
-- **Kubernetes Distro Being Used**: 
-- **Other**: 
+- **Vulnerable Software / Dependency**: 
 
 ### Mitigation Steps
 Steps that can be taken to mitigate the CVE.
-
-### Visual Proof (screenshots, videos, text, etc)
 
 ### Severity/Priority
 


### PR DESCRIPTION
## Description

- add a `cve_report.md` so contributors can manually report a CVE on a given UDS package
- more details in #47 

## Related Issue

Fixes #47 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-#TEMPLATE_APPLICATION_NAME#/blob/main/CONTRIBUTING.md#developer-workflow) followed
