### PR TITLE
chore: remove old instructions, add note to codeowners template

### DIFF
--- a/CODEOWNERS-template.md
+++ b/CODEOWNERS-template.md
@@ -8,7 +8,7 @@ The `CODEOWNERS` file should follow the below format, you can even just copy / p
 /CODEOWNERS @jeff-mccoy @daveworth 
 /LICENS* @jeff-mccoy @austenbryan
 ```
-*NOTE:* You will need to add `uds-package-maintainers` to the repository with a minimum of write access for the `CODEOWNERS` file to be valid
+*NOTE:* You will need to add `uds-package-maintainers` to the repository with admin access for the `CODEOWNERS` file to be valid
 
 If you would like to add optional package reviewers, such as the creator of the app, you can append creators after `uds-package-maintainers`
 

--- a/CODEOWNERS-template.md
+++ b/CODEOWNERS-template.md
@@ -8,6 +8,7 @@ The `CODEOWNERS` file should follow the below format, you can even just copy / p
 /CODEOWNERS @jeff-mccoy @daveworth 
 /LICENS* @jeff-mccoy @austenbryan
 ```
+*NOTE:* You will need to add `uds-package-maintainers` to the repository with a minimum of write access for the `CODEOWNERS` file to be valid
 
 If you would like to add optional package reviewers, such as the creator of the app, you can append creators after `uds-package-maintainers`
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ The following files will need to be customized for the application being package
 
 4. Almost there...
    - `mv README-template.md README.md`
-   - `rm -rf tasks/template.yaml`
-   - Remove extra lines from [tasks.yaml](./tasks.yaml)
    - Follow the `CODEOWNERS-template.md` to update your `CODEOWNERS` file.
 
 You are ready to start integrating (and testing with CI) your application with UDS Core!

--- a/docs/justifications.md
+++ b/docs/justifications.md
@@ -8,6 +8,6 @@ Details about the #TEMPLATE_APPLICATION_DISPLAY_NAME# package and requirements o
 Example: "The Upstream implementation of APP_XYZ does not expose a metrics endpoint, issue [#123](https://upstream.project/issue/123) has been opened to track this feature request."
 -->
 
-## <Requirement X> 
+## <Requirement X>
 
 ### Additional Information


### PR DESCRIPTION
## Description
A minor cleanup to remove old instructions, an extra space, and add a note about adding the `uds-package-maintainers` group to the repo to ensure the `CODEOWNERS` file is valid after update.

## Related Issue
N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-#TEMPLATE_APPLICATION_NAME#/blob/main/CONTRIBUTING.md#developer-workflow) followed
