### PR TITLE
refactor(tasks): remove redundant create-package tasks

### DIFF
--- a/tasks.yaml
+++ b/tasks.yaml
@@ -18,7 +18,6 @@ tasks:
   - name: default
     description: Setup k3d cluster, deploy package
     actions:
-      - task: create-dev-package
       - task: setup:k3d-test-cluster
       - task: create-deploy-test-bundle
 
@@ -50,7 +49,6 @@ tasks:
   - name: test-install
     description: Test deploying the current branch to a new cluster
     actions:
-      - task: create-dev-package
       - task: setup:k3d-test-cluster
       - task: create-deploy-test-bundle
       # - task: compliance:validate
@@ -69,9 +67,6 @@ tasks:
   - name: publish-package
     description: Build and publish the packages
     actions:
-      - description: Create the package
-        task: create:package
-
       - description: Setup the cluster
         task: setup:k3d-test-cluster
 


### PR DESCRIPTION
Simplified task definitions by removing unnecessary `create-dev-package` and `create:package` steps. These actions were redundant as the required package creation is covered elsewhere in the workflow. This change improves task clarity and prevents automated actions from building the same zarf package twice.

## Description

...

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/uds-packages/uds-package-#TEMPLATE_APPLICATION_NAME#/blob/main/CONTRIBUTING.md#developer-workflow) followed
