### PR TITLE
fix: remove playwright image from package deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,7 @@
       "groupName": "#TEMPLATE_APPLICATION_DISPLAY_NAME# Package Dependencies",
       "labels": ["package-deps"],
       "commitMessageTopic": "package-deps",
+      "matchPackageNames": ["!/^mcr\\.microsoft\\.com\\/playwright$/"],
       "matchDatasources": ["docker", "helm", "git-tags"]
     },
     {


### PR DESCRIPTION
## Description

Removes the playwright image from package deps which will add it to the support deps alongside its package version

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/uds-packages/uds-package-#TEMPLATE_APPLICATION_NAME#/blob/main/CONTRIBUTING.md#developer-workflow) followed
